### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -41,8 +41,8 @@ To not get too bored by the wall 🧱 of text, let's have a look
 at the different options individually.
 As smaller walls 🧱 of text...
 Though, I don't know how exciting
-these section will be 😅.
-Some section will contain more context or additional information.
+these sections will be 😅.
+Some sections will contain more context or additional information.
 
 Just jump to the sections that sound interesting:
 

--- a/src/isd_tui/isd.py
+++ b/src/isd_tui/isd.py
@@ -667,7 +667,7 @@ class Settings(BaseSettings):
             Seconds to wait before computing state updates (default 0.05s).
             For example, time after input has changed before updating the selection.
             Or time to wait to update preview window after highlighting new value.
-            The idea is to minimize the number of 'irrelvant' updated during fast
+            The idea is to minimize the number of 'irrelevant' updated during fast
             scrolling through the unit list or quick typing."""),
     )
 


### PR DESCRIPTION
This PR fixes some typos in the config documentation and the docs.

(A great tool, by the way. Thank you for creating it :heart:)